### PR TITLE
Fix software updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "host-insight-client"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "async-channel"
@@ -587,6 +587,7 @@ dependencies = [
 name = "host-insight-client"
 version = "0.4.7"
 dependencies = [
+ "anyhow",
  "async-lock",
  "async-std",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ name = "host-insight-client"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0.75"
 async-lock = "2.6.0"
 clap = { version = "3.2.23", features = ["cargo"] }
 tonic = { version = "0.8.2", features = ["tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
 name = "host-insight-client"
 description = "A remote I/O client for GNU/Linux"
 homepage = "https://github.com/hostmobility"
-version = "0.4.7"
+version = "0.5.0"
 edition = "2021"
 license = "GPL-3.0-or-later"
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Host requirements:
 - curl
 - glibc v2.28 or later
 - OpenSSL
-- opkg
 - md5sum
 - systemd
+- [host-insight-helper](https://github.com/hostmobility/meta-mobility-poky-distro/tree/master/recipes-support/host-insight-helper)
 
 ## CAN
 

--- a/scripts/exit-handler.sh
+++ b/scripts/exit-handler.sh
@@ -19,8 +19,12 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 
 etime=62
+swupdate=100
 
 if [ "$EXIT_STATUS" = "$etime" ]; then
   logger "host-insight-client timed out. Rebooting system"
   systemctl reboot
+elif [ "$EXIT_STATUS" = "$swupdate" ]; then
+  logger "Upgrading the host-insight client"
+  /opt/host-insight-helper/host-insight-helper.sh &
 fi

--- a/src/can.rs
+++ b/src/can.rs
@@ -23,7 +23,7 @@ use futures::{stream, stream::StreamExt};
 use lazy_static::lazy_static;
 use lib::{
     host_insight::{agent_client::AgentClient, can_signal, CanMessage, CanSignal},
-    CanPort, ErrorCodes, CONFIG, CONF_DIR,
+    CanPort, ExitCodes, CONFIG, CONF_DIR,
 };
 use std::collections::HashMap;
 use std::error::Error;
@@ -92,7 +92,7 @@ pub async fn can_sender(channel: Channel) -> Result<(), Box<dyn Error>> {
 
 pub async fn can_monitor(port: &CanPort) -> Result<(), Box<dyn Error>> {
     let dbc = load_dbc_file(CONFIG.can.as_ref().unwrap().dbc_file.as_ref().unwrap())
-        .unwrap_or_else(|_| std::process::exit(ErrorCodes::Enoent as i32));
+        .unwrap_or_else(|_| std::process::exit(ExitCodes::Enoent as i32));
 
     let mut map = HashMap::new();
     let mut prev_map = HashMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,10 @@ use serde_derive::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
-pub enum ErrorCodes {
-    Enoent = 2, // No such file or directory
-    Etime = 62, // Timer expired
+pub enum ExitCodes {
+    Enoent = 2,     // No such file or directory
+    Etime = 62,     // Timer expired
+    SwUpdate = 100, // Software upgrade
 }
 
 pub mod host_insight {

--- a/src/net.rs
+++ b/src/net.rs
@@ -23,7 +23,7 @@ use super::utils::{clean_up, fetch_resource, get_md5sum, update_client};
 use async_std::task;
 use lib::{
     host_insight::{agent_client::AgentClient, reply::Action, Reply, State},
-    ErrorCodes, Identity, CONFIG, CONF_DIR, GIT_COMMIT_DESCRIBE, IDENTITY,
+    ExitCodes, Identity, CONFIG, CONF_DIR, GIT_COMMIT_DESCRIBE, IDENTITY,
 };
 use rand::Rng;
 use std::collections::HashMap;
@@ -207,10 +207,10 @@ pub async fn handle_send_result(
             Some(Action::SwUpdateMsg(msg)) => {
                 *s = CONFIG.time.sleep_min_s;
                 match update_client(&msg.version) {
-                    Err(e) => panic!("Error: {e}"),
+                    Err(e) => eprintln!("{}: Failed to trigger software update.", e),
                     Ok(_) => {
                         clean_up();
-                        std::process::exit(0);
+                        std::process::exit(ExitCodes::SwUpdate as i32);
                     }
                 };
             }
@@ -233,7 +233,7 @@ pub async fn handle_send_result(
             if *s > CONFIG.time.sleep_max_s {
                 eprintln!("Max sleep time reached");
                 // Exit with code to let e.g. a systemd service handle this situation.
-                std::process::exit(ErrorCodes::Etime as i32);
+                std::process::exit(ExitCodes::Etime as i32);
             };
 
             // Double the sleep time to create a back-off effect.


### PR DESCRIPTION
It's impossible to upgrade the running client application by fetching a new version of itself.  Instead, let the insight helper script do it.

- Rename ErrorCodes -> ExitCodes and add a code for software updates.
- Call host-insight-helper to perform the update
- Don't panic if software update fails. This is to prevent entering a reboot loop.
- Remove most of the opkg commands from the client
- Use anyhow for custom error messages

This requires [changes to the host insight client helper](https://github.com/hostmobility/meta-mobility-poky-distro/pull/21).