### PR TITLE
Do not exit if error message contains 'DB'

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -232,9 +232,14 @@ pub async fn handle_send_result(
 
             if *s > CONFIG.time.sleep_max_s {
                 eprintln!("Max sleep time reached");
-                // Exit with code to let e.g. a systemd service handle this situation.
-                std::process::exit(ExitCodes::Etime as i32);
-            };
+
+                // Database issues, such as unassigned instance ID, should not trigger an exit
+                let error_message = format!("{:?}", e);
+                if !error_message.contains("DB") {
+                    // Exit with code to let e.g. a systemd service handle this situation.
+                    std::process::exit(ExitCodes::Etime as i32);
+                }
+            }
 
             // Double the sleep time to create a back-off effect.
             *s *= 2;


### PR DESCRIPTION
Continue to let all errors double the sleep time, but don't exit the application if the error has something to do with the server db.